### PR TITLE
Remove mediation config redundant reading

### DIFF
--- a/com.wso2telco.dep.hub.creditapi/com.wso2telco.dep.hub.creditapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.creditapi.resource.apply.recall.Sequence.xml
+++ b/com.wso2telco.dep.hub.creditapi/com.wso2telco.dep.hub.creditapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.creditapi.resource.apply.recall.Sequence.xml
@@ -23,7 +23,6 @@
   	<sequence key="com.wso2telco.dep.common.handle.gateway.error.Sequence"/>
 
 	<!-- retrieve hub url from registry -->
-	<property expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')" name="mediationConfig" scope="default" type="OM"/>
 	<property expression="$ctx:mediationConfig//huburl" name="hubUrl" scope="default" type="STRING"/>
 
     <property expression="json-eval($.creditApplyResponse.receiptResponse.notifyURL)" name="notifyURL" scope="default" type="STRING"/>

--- a/com.wso2telco.dep.hub.creditapi/com.wso2telco.dep.hub.creditapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.creditapi.resource.notification.Sequence.xml
+++ b/com.wso2telco.dep.hub.creditapi/com.wso2telco.dep.hub.creditapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.creditapi.resource.notification.Sequence.xml
@@ -13,8 +13,7 @@
   	<sequence key="com.wso2telco.dep.common.operator.endpoint.retriever.Sequence"/>
 
 	<!-- retrieve hub url from registry -->
-	<property expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')" name="mediationConfig" scope="default" type="OM"/>
-  	<property expression="$ctx:mediationConfig//huburl" name="hubUrl" scope="default" type="STRING"/>   	
+  	<property expression="$ctx:mediationConfig//huburl" name="hubUrl" scope="default" type="STRING"/>
   	  
 	<class name="org.wso2telco.dep.nashornmediator.NashornMediator">
 		<property name="script" value="

--- a/com.wso2telco.dep.hub.creditapi/com.wso2telco.dep.hub.creditapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.creditapi.resource.refund.in.Sequence.xml
+++ b/com.wso2telco.dep.hub.creditapi/com.wso2telco.dep.hub.creditapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.creditapi.resource.refund.in.Sequence.xml
@@ -127,7 +127,6 @@
 	<sequence key="com.wso2telco.dep.common.handle.gateway.error.Sequence"/>
 	
 	<!-- retrieve hub url from registry -->
-	<property expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')" name="mediationConfig" scope="default" type="OM"/>
 	<property expression="$ctx:mediationConfig//huburl" name="hubUrl" scope="default" type="STRING"/>
 	
 	<class name="org.wso2telco.dep.nashornmediator.NashornMediator">

--- a/com.wso2telco.dep.hub.creditapi/com.wso2telco.dep.hub.creditapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.creditapi.resource.refund.msisdnValidator.Sequence.xml
+++ b/com.wso2telco.dep.hub.creditapi/com.wso2telco.dep.hub.creditapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.creditapi.resource.refund.msisdnValidator.Sequence.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sequence name="com.wso2telco.dep.hub.creditapi.resource.refund.msisdnValidator.Sequence" onError="com.wso2telco.dep.common.response.unexpectedError.Sequence" trace="disable" xmlns="http://ws.apache.org/ns/synapse">
     
-    <property expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')" name="mediationConfig" scope="default" type="OM"/>
     <property expression="$ctx:mediationConfig//msisdn_regex" name="msisdnRegex" scope="default" type="STRING"/>
     <property expression="$ctx:mediationConfig//msisdn_regex_num_grp" name="msisdnRegexGr" scope="default" type="INTEGER"/>
     

--- a/com.wso2telco.dep.hub.creditapi/com.wso2telco.dep.hub.creditapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.creditapi.resource.refund.recall.Sequence.xml
+++ b/com.wso2telco.dep.hub.creditapi/com.wso2telco.dep.hub.creditapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.creditapi.resource.refund.recall.Sequence.xml
@@ -23,8 +23,7 @@
   	<sequence key="com.wso2telco.dep.common.handle.gateway.error.Sequence"/>  	
 
 	<!-- retrieve hub url from registry -->
-	<property expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')" name="mediationConfig" scope="default" type="OM"/>
-  	<property expression="$ctx:mediationConfig//huburl" name="hubUrl" scope="default" type="STRING"/>  
+  	<property expression="$ctx:mediationConfig//huburl" name="hubUrl" scope="default" type="STRING"/>
 
     <property expression="json-eval($.refundResponse.receiptResponse.notifyURL)" name="notifyURL" scope="default" type="STRING"/>
     <property expression="fn:normalize-space($ctx:notifyURL)" name="notifyURL" scope="default" type="STRING" pattern="((^(?!null).*$)|(^(null).+$))" group="1"/>

--- a/com.wso2telco.dep.hub.customerinfoapi/com.wso2telco.dep.hub.customerinfoapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.customerinfoapi.handle.attributes.Sequence.xml
+++ b/com.wso2telco.dep.hub.customerinfoapi/com.wso2telco.dep.hub.customerinfoapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.customerinfoapi.handle.attributes.Sequence.xml
@@ -41,10 +41,6 @@
     name="requestIdentifier" scope="default" type="STRING"/>
   <property expression="fn:normalize-space($ctx:requestIdentifier)"
     name="requestIdentifier" scope="default" type="STRING"/>
-  <!-- load mediation configurations from registry -->
-  <property
-    expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')"
-    name="mediationConfig" scope="default" type="OM"/>
   <!-- validate mandatory parameters of the request -->
   <filter xpath="not(boolean($ctx:requestIdentifier))">
     <then>

--- a/com.wso2telco.dep.hub.customerinfoapi/com.wso2telco.dep.hub.customerinfoapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.customerinfoapi.handle.attributes.recaller.Sequence.xml
+++ b/com.wso2telco.dep.hub.customerinfoapi/com.wso2telco.dep.hub.customerinfoapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.customerinfoapi.handle.attributes.recaller.Sequence.xml
@@ -41,10 +41,6 @@
     name="requestIdentifier" scope="default" type="STRING"/>
   <property expression="fn:normalize-space($ctx:requestIdentifier)"
     name="requestIdentifier" scope="default" type="STRING"/>
-  <!-- load mediation configurations from registry -->
-  <property
-    expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')"
-    name="mediationConfig" scope="default" type="OM"/>
   <!-- validate mandatory parameters of the request -->
   <filter xpath="not(boolean($ctx:requestIdentifier))">
     <then>

--- a/com.wso2telco.dep.hub.customerinfoapi/com.wso2telco.dep.hub.customerinfoapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.customerinfoapi.handle.profile.Sequence.xml
+++ b/com.wso2telco.dep.hub.customerinfoapi/com.wso2telco.dep.hub.customerinfoapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.customerinfoapi.handle.profile.Sequence.xml
@@ -37,10 +37,6 @@
     name="requestIdentifier" scope="default" type="STRING"/>
   <property expression="fn:normalize-space($ctx:requestIdentifier)"
     name="requestIdentifier" scope="default" type="STRING"/>
-  <!-- load mediation configurations from registry -->
-  <property
-    expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')"
-    name="mediationConfig" scope="default" type="OM"/>
   <!-- validate mandatory parameters of the request -->
   <filter xpath="not(boolean($ctx:requestIdentifier))">
     <then>

--- a/com.wso2telco.dep.hub.customerinfoapi/com.wso2telco.dep.hub.customerinfoapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.customerinfoapi.handle.profile.recaller.Sequence.xml
+++ b/com.wso2telco.dep.hub.customerinfoapi/com.wso2telco.dep.hub.customerinfoapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.customerinfoapi.handle.profile.recaller.Sequence.xml
@@ -37,10 +37,6 @@
     name="requestIdentifier" scope="default" type="STRING"/>
   <property expression="fn:normalize-space($ctx:requestIdentifier)"
     name="requestIdentifier" scope="default" type="STRING"/>
-  <!-- load mediation configurations from registry -->
-  <property
-    expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')"
-    name="mediationConfig" scope="default" type="OM"/> 
   <!-- validate mandatory parameters of the request -->
   <filter xpath="not(boolean($ctx:requestIdentifier))">
     <then>

--- a/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.listService.recaller.Sequence.xml
+++ b/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.listService.recaller.Sequence.xml
@@ -18,8 +18,6 @@
     <property expression="fn:normalize-space($ctx:offset)" name="offset" scope="default" type="STRING"/>
     <property description="limit" expression="$ctx:query.param.limit" name="limit" scope="default" type="STRING"/>
     <property expression="fn:normalize-space($ctx:limit)" name="limit" scope="default" type="STRING"/>
-    <!-- load mediation configurations from registry -->
-    <property expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')" name="mediationConfig" scope="default" type="OM"/>
     <!-- MANDATORY PARAMETER VALIDATION -->
     <filter xpath="boolean($ctx:mcc)">
         <then>

--- a/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.listServiceByCustomer.Sequence.xml
+++ b/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.listServiceByCustomer.Sequence.xml
@@ -18,8 +18,6 @@
     <property expression="fn:normalize-space($ctx:offset)" name="offset" scope="default" type="STRING"/>
     <property description="limit" expression="$ctx:query.param.limit" name="limit" scope="default" type="STRING"/>
     <property expression="fn:normalize-space($ctx:limit)" name="limit" scope="default" type="STRING"/>
-    <!-- load mediation configurations from registry -->
-    <property expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')" name="mediationConfig" scope="default" type="OM"/>
     <!-- MANDATORY PARAMETER VALIDATION -->
     <filter xpath="boolean($ctx:mcc)">
         <then>

--- a/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.provisionService.Sequence.xml
+++ b/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.provisionService.Sequence.xml
@@ -147,7 +147,7 @@
             </filter>
         </else>
     </filter>
-    <property expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')" name="mediationConfig" scope="default" type="OM"/>
+    <!-- retrieve hub url from registry -->
     <property expression="$ctx:mediationConfig//huburl" name="HUB_URL" scope="default" type="STRING"/>
 	<call-template target="com.wso2telco.dep.common.notification.url.readModify.Template">
    		<with-param name="notifyURL" value="{$ctx:notifyURL}"/>	

--- a/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.provisioning.recaller.Sequence.xml
+++ b/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.provisioning.recaller.Sequence.xml
@@ -45,7 +45,6 @@
     </call-template>
     <sequence key="com.wso2telco.dep.common.mccMncValidator.Sequence"/>
     <!-- retrieve hub url from registry -->
-    <property expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')" name="mediationConfig" scope="default" type="OM"/>
     <property expression="$ctx:mediationConfig//huburl" name="HUB_URL" scope="default" type="STRING"/>
     <!-- retrieve operator's endpoint -->
     <sequence key="com.wso2telco.dep.common.endpoint.retriever.Sequence"/>

--- a/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.queryApplicable.Sequence.xml
+++ b/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.queryApplicable.Sequence.xml
@@ -18,8 +18,6 @@
     <property expression="fn:normalize-space($ctx:offset)" name="offset" scope="default" type="STRING"/>
     <property description="limit" expression="$ctx:query.param.limit" name="limit" scope="default" type="STRING"/>
     <property expression="fn:normalize-space($ctx:limit)" name="limit" scope="default" type="STRING"/>
-    <!-- load mediation configurations from registry -->
-    <property expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')" name="mediationConfig" scope="default" type="OM"/>
     <!-- REQUEST PARAMETER VALIDATION -->
     <filter xpath="boolean($ctx:mcc)">
         <then>

--- a/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.queryApplicable.recaller.Sequence.xml
+++ b/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.queryApplicable.recaller.Sequence.xml
@@ -18,8 +18,6 @@
     <property expression="fn:normalize-space($ctx:offset)" name="offset" scope="default" type="STRING"/>
     <property description="limit" expression="$ctx:query.param.limit" name="limit" scope="default" type="STRING"/>
     <property expression="fn:normalize-space($ctx:limit)" name="limit" scope="default" type="STRING"/>
-    <!-- load mediation configurations from registry -->
-    <property expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')" name="mediationConfig" scope="default" type="OM"/>
     <filter xpath="boolean($ctx:mcc)">
         <then>
             <filter xpath="not(boolean($ctx:mnc))">

--- a/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.unprovision.recaller.Sequence.xml
+++ b/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.unprovision.recaller.Sequence.xml
@@ -45,7 +45,6 @@
     </call-template>
     <sequence key="com.wso2telco.dep.common.mccMncValidator.Sequence"/>
     <!-- retrieve hub url from registry -->
-    <property expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')" name="mediationConfig" scope="default" type="OM"/>
     <property expression="$ctx:mediationConfig//huburl" name="HUB_URL" scope="default" type="STRING"/>
     <!-- retrieve operator's endpoint -->
     <sequence key="com.wso2telco.dep.common.endpoint.retriever.Sequence"/>

--- a/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.unprovisionService.Sequence.xml
+++ b/com.wso2telco.dep.hub.provisionapi/com.wso2telco.dep.hub.provisionapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.provisionapi.unprovisionService.Sequence.xml
@@ -99,7 +99,7 @@
     </call-template>
     <sequence key="com.wso2telco.dep.common.endpoint.retriever.Sequence"/>
     <sequence key="com.wso2telco.dep.common.select.token.Sequence"/>
-    <property expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')" name="mediationConfig" scope="default" type="OM"/>
+    <!-- retrieve hub url from registry -->
     <property expression="$ctx:mediationConfig//huburl" name="HUB_URL" scope="default" type="STRING"/>
 	<call-template target="com.wso2telco.dep.common.notification.url.readModify.Template">
    		<with-param name="notifyURL" value="{$ctx:notifyURL}"/>	

--- a/com.wso2telco.dep.hub.walletapi/com.wso2telco.dep.hub.walletapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.walletapi.handle.balance.Sequence.xml
+++ b/com.wso2telco.dep.hub.walletapi/com.wso2telco.dep.hub.walletapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.walletapi.handle.balance.Sequence.xml
@@ -12,9 +12,6 @@
   <property expression="get-property('endUserId')" name="MSISDN"
     scope="default" type="STRING"/>
   <!-- retrieve hub url from registry -->
-  <property
-    expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')"
-    name="mediationConfig" scope="default" type="OM"/>
   <property expression="$ctx:mediationConfig//huburl" name="HUB_URL"
     scope="default" type="STRING"/>
   <!-- retrieve operator's endpoint -->

--- a/com.wso2telco.dep.hub.walletapi/com.wso2telco.dep.hub.walletapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.walletapi.handle.balance.recaller.Sequence.xml
+++ b/com.wso2telco.dep.hub.walletapi/com.wso2telco.dep.hub.walletapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.walletapi.handle.balance.recaller.Sequence.xml
@@ -13,9 +13,6 @@
   <property expression="get-property('endUserId')" name="MSISDN"
     scope="default" type="STRING"/>
   <!-- retrieve hub url from registry -->
-  <property
-    expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')"
-    name="mediationConfig" scope="default" type="OM"/>
   <property expression="$ctx:mediationConfig//huburl" name="HUB_URL"
     scope="default" type="STRING"/>
   <!-- retrieve operator's endpoint -->

--- a/com.wso2telco.dep.hub.walletapi/com.wso2telco.dep.hub.walletapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.walletapi.handle.listing.Sequence.xml
+++ b/com.wso2telco.dep.hub.walletapi/com.wso2telco.dep.hub.walletapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.walletapi.handle.listing.Sequence.xml
@@ -12,9 +12,6 @@
   <property expression="get-property('endUserId')" name="MSISDN"
     scope="default" type="STRING"/>
   <!-- retrieve hub url from registry -->
-  <property
-    expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')"
-    name="mediationConfig" scope="default" type="OM"/>
   <property expression="$ctx:mediationConfig//huburl" name="HUB_URL"
     scope="default" type="STRING"/>
   <!-- retrieve operator's endpoint -->

--- a/com.wso2telco.dep.hub.walletapi/com.wso2telco.dep.hub.walletapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.walletapi.handle.listing.recaller.Sequence.xml
+++ b/com.wso2telco.dep.hub.walletapi/com.wso2telco.dep.hub.walletapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.walletapi.handle.listing.recaller.Sequence.xml
@@ -13,9 +13,6 @@
   <property expression="get-property('endUserId')" name="MSISDN"
     scope="default" type="STRING"/>
   <!-- retrieve hub url from registry -->
-  <property
-    expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')"
-    name="mediationConfig" scope="default" type="OM"/>
   <property expression="$ctx:mediationConfig//huburl" name="HUB_URL"
     scope="default" type="STRING"/>
   <!-- retrieve operator's endpoint -->

--- a/com.wso2telco.dep.hub.walletapi/com.wso2telco.dep.hub.walletapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.walletapi.handle.refund.Sequence.xml
+++ b/com.wso2telco.dep.hub.walletapi/com.wso2telco.dep.hub.walletapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.walletapi.handle.refund.Sequence.xml
@@ -193,9 +193,6 @@
     <with-param name="clientCorrelator" value="{$ctx:clientCorrelator}"/>
   </call-template>
   <!-- retrieve hub url from registry -->
-  <property
-    expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')"
-    name="mediationConfig" scope="default" type="OM"/>
   <property expression="$ctx:mediationConfig//huburl" name="HUB_URL"
     scope="default" type="STRING"/>
   <!-- retrieve operator's endpoint -->

--- a/com.wso2telco.dep.hub.walletapi/com.wso2telco.dep.hub.walletapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.walletapi.handle.refund.recaller.Sequence.xml
+++ b/com.wso2telco.dep.hub.walletapi/com.wso2telco.dep.hub.walletapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.walletapi.handle.refund.recaller.Sequence.xml
@@ -13,9 +13,6 @@
   <property expression="get-property('endUserId')" name="MSISDN"
     scope="default" type="STRING"/>
   <!-- retrieve hub url from registry -->
-  <property
-    expression="get-property('registry', 'conf:/repository/wso2telco/configurations/mediationConfig.xml')"
-    name="mediationConfig" scope="default" type="OM"/>
   <property expression="$ctx:mediationConfig//huburl" name="HUB_URL"
     scope="default" type="STRING"/>
   <!-- retrieve operator's endpoint -->


### PR DESCRIPTION
Remove all mediation config readings from synapse files.
MediationConfig entry reading is moved to common mediation : https://github.com/Buddhima/mediation-dep-common/blob/bcd42d1f334ed2dadccb53411ec5581c6841a495/com.wso2telco.dep.common.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.common.main.request.Sequence.xml#L5