### PR TITLE
Bug fix Credit API - Removed unwanted notifyurl changing code from apply a credit sequence

### DIFF
--- a/com.wso2telco.dep.hub.creditapi/com.wso2telco.dep.hub.creditapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.creditapi.resource.apply.in.Sequence.xml
+++ b/com.wso2telco.dep.hub.creditapi/com.wso2telco.dep.hub.creditapi.synapse/src/main/synapse-config/sequences/com.wso2telco.dep.hub.creditapi.resource.apply.in.Sequence.xml
@@ -49,23 +49,6 @@
 	<!-- retrieve operator's endpoint -->
 	<sequence key="com.wso2telco.dep.common.endpoint.retriever.Sequence"/>
 
-    <filter xpath="boolean($ctx:notifyURL)">
-		<then>
-			<property  expression="get-property('registry', 'conf:/repository/wso2telco/configurations/notificationURL.xml')"
-			  name="notificationURLConfig" scope="default" type="OM"/>
-			<property expression="$ctx:notificationURLConfig//credit" name="NOTIFICATION_URL" scope="default" type="STRING"/>
-			<!-- save service provider's notify url and generate new notify url from hub -->
-			<sequence key="com.wso2telco.dep.common.notification.url.modify.Sequence"/>
-			<filter regex="true" source="get-property('INTERNAL_ERROR')">
-			  <then>
-			    <sequence key="com.wso2telco.dep.common.response.exceptions.Sequence"/>
-			  </then>
-			  <else/>
-			</filter>
-		</then>
-		<else/>
-    </filter>
-
 	<!-- retrieve operator's access token -->
 	<sequence key="com.wso2telco.dep.common.select.token.Sequence"/>
 	


### PR DESCRIPTION
The same logic handled by calling notification.url.readModify.Template.